### PR TITLE
Support meta.v1

### DIFF
--- a/examples/using-jquery-for-ajax.js
+++ b/examples/using-jquery-for-ajax.js
@@ -17,7 +17,7 @@ var v1 = new v1sdk.V1Meta({
 	protocol: protocol,
 	username: username,
 	password: password,
-	post: function (url, data, headerObj) {
+	postFn: function (url, data, headerObj) {
 		// Be sure to return jquery's jqxhr object/the post results
 		return $.ajax({
 			url: url,
@@ -26,7 +26,17 @@ var v1 = new v1sdk.V1Meta({
 			headers: headerObj, // Include provided authorization headers { Authorization: 'Basic: .....' }
 			dataType: 'json' // SDK only supports JSON from the V1 Server
 		});
-	}
+	},
+    getFn: function (url, data, headerObj) {
+        // Be sure to return jquery's jqxhr object/the post results
+        return $.ajax({
+            url: url,
+            method: 'GET',
+            data: data,
+            headers: headerObj, // Include provided authorization headers { Authorization: 'Basic: .....' }
+            dataType: 'json' // SDK only supports JSON from the V1 Server
+        });
+    }
 });
 
 // Create Asset Actual

--- a/examples/using-jquery-for-ajax.js
+++ b/examples/using-jquery-for-ajax.js
@@ -26,15 +26,6 @@ var v1 = new v1sdk.V1Meta({
 			headers: headerObj, // Include provided authorization headers { Authorization: 'Basic: .....' }
 			dataType: 'json' // SDK only supports JSON from the V1 Server
 		});
-	},
-	get: function (url, data) {
-		return $.ajax({
-			url: url,
-			method: 'GET',
-			data: data,
-			dataType: 'json' // SDK only supports JSON from the V1 Server
-
-		});
 	}
 });
 

--- a/examples/using-jquery-for-ajax.js
+++ b/examples/using-jquery-for-ajax.js
@@ -37,3 +37,12 @@ v1.create('Actual', {Value: 5.4, Date: new Date()})
 	.catch(function (error) {
 		console.log(error);
 	});
+
+// Retrieve a description of all the Attributes, Operations for a given AssetType
+v1.queryDefinition('Story')
+    .then(function (result) {
+       console.log(result);
+    })
+    .catch(function(error) {
+        console.log(eror);
+    });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v1sdk",
-  "version": "1.0.10",
+  "version": "1.1.9",
   "description": "VersionOne API Client for JavaScript",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v1sdk",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "VersionOne API Client for JavaScript",
   "license": "MIT",
   "keywords": [

--- a/src/V1Meta.js
+++ b/src/V1Meta.js
@@ -54,4 +54,10 @@ export default class V1Meta {
         const headers = createHeaderObj(this.authHeader);
         return Promise.resolve(this.postFn(url, null, headers));
     }
+
+    queryDefinition(assetType) {
+        const url = `${this.urls.meta()}/${assetType}`;
+        const headers = createHeaderObj(this.authHeader);
+        return Promise.resolve(this.postFn(url, null, headers));
+    }
 }

--- a/src/V1Meta.js
+++ b/src/V1Meta.js
@@ -16,9 +16,10 @@ const createHeaderObj = authentication => {
 };
 
 export default class V1Meta {
-    constructor({hostname, instance, protocol, port, username, password, postFn}) {
+    constructor({hostname, instance, protocol, port, username, password, postFn, getFn}) {
         this.urls = getUrlsForV1Server({hostname, instance, protocol, port});
         this.postFn = postFn;
+        this.getFn = getFn;
         if (username && password) {
             const encodedAuthenticationCredentials = btoa(`${username}:${password}`);
             this.authHeader = `Basic ${encodedAuthenticationCredentials}`;
@@ -58,6 +59,6 @@ export default class V1Meta {
     queryDefinition(assetType) {
         const url = `${this.urls.meta()}/${assetType}`;
         const headers = createHeaderObj(this.authHeader);
-        return Promise.resolve(this.postFn(url, null, headers));
+        return Promise.resolve(this.getFn(url, null, headers));
     }
 }

--- a/src/V1Meta.specs.js
+++ b/src/V1Meta.specs.js
@@ -21,7 +21,7 @@ describe('src/V1Meta', function() {
         });
 
         describe('when creating an asset', () => {
-            let transformedAssetData, url, queryUrl, encodedCreds, btoa;
+            let transformedAssetData, url, queryUrl, metaUrl, encodedCreds, btoa;
             beforeEach(() => {
                 let assetType = 'Actual';
                 let assetData = {};
@@ -29,10 +29,12 @@ describe('src/V1Meta', function() {
                 transformDataToAsset = sinon.stub().withArgs(assetType, assetData).returns(transformedAssetData);
                 url = 'my V1 Instance URL';
                 queryUrl = 'my query URL';
+                metaUrl = 'my meta URL';
                 encodedCreds = 'some encoded stuff';
                 getUrlsForV1Server = sinon.stub().withArgs({...v1ServerInfo}).returns({
                     rest: sinon.stub().returns(url),
-                    query: sinon.stub().returns(queryUrl)
+                    query: sinon.stub().returns(queryUrl),
+                    meta: sinon.stub().returns(metaUrl)
                 });
                 btoa = sinon.stub().withArgs(`${v1ServerInfo.username}:${v1ServerInfo.password}`).returns(encodedCreds);
                 Sut.__Rewire__('transformDataToAsset', transformDataToAsset);
@@ -146,6 +148,17 @@ describe('src/V1Meta', function() {
                     actual = (new Sut({ ...v1ServerInfowithUsernamePassword,
                         postFn
                     })).query({from: 'Epic', select: ['Name']})
+                });
+                it('it should return an ES2015 Promise', () => {
+                    actual.should.be.an.instanceOf(Promise);
+                });
+            });
+
+            describe('when querying for a definition', () => {
+                beforeEach(() => {
+                    actual = (new Sut({ ...v1ServerInfowithUsernamePassword,
+                        postFn
+                    })).queryDefinition("Story")
                 });
                 it('it should return an ES2015 Promise', () => {
                     actual.should.be.an.instanceOf(Promise);
@@ -392,6 +405,30 @@ describe('src/V1Meta', function() {
 
                     it('it should provide the postFn with the proper API URL for the intended operation', () => {
                         postFn.calledWith(`${url}/Member/20?op=${operationName}`, null, expectedHeaders).should.be.true;
+                    });
+                });
+            });
+
+            describe('given an assetType', () => {
+                let assetType, url;
+                beforeEach(() => {
+                    assetType = "Story"
+                });
+                describe('when query for a definition', () => {
+                    beforeEach(() => {
+                        postFn = sinon.stub().returns(Promise.resolve());
+                        getUrlsForV1Server = sinon.stub().withArgs({...v1ServerInfo}).returns({
+                            meta: sinon.stub().returns(url)
+                        });
+                        Sut.__Rewire__('getUrlsForV1Server', getUrlsForV1Server);
+                        actual = (new Sut({
+                            ...v1ServerInfowithUsernamePassword,
+                            postFn
+                        })).queryDefinition(assetType);
+                    });
+
+                    it('it should provide the postFn with the proper API URL for the assetType', () => {
+                        postFn.calledWith(`${url}/${assetType}`, null, expectedHeaders).should.be.true;
                     });
                 });
             });

--- a/src/V1Meta.specs.js
+++ b/src/V1Meta.specs.js
@@ -9,7 +9,7 @@ describe('src/V1Meta', function() {
     let transformDataToAsset, getUrlsForV1Server, actual;
 
     describe('given a V1 hostname, server instance, protocol, port, post and get methods and no username or password', () => {
-        let v1ServerInfo, postFn;
+        let v1ServerInfo, postFn, getFn;
         beforeEach(() => {
             v1ServerInfo = {
                 hostname: 'some URL',
@@ -18,6 +18,7 @@ describe('src/V1Meta', function() {
                 port: '8081'
             };
             postFn = sinon.stub().returns({then: () => serverData});
+            getFn = sinon.stub().returns({then: () => serverData});
         });
 
         describe('when creating an asset', () => {
@@ -87,10 +88,11 @@ describe('src/V1Meta', function() {
         });
 
         describe('given a post method that does not return a ES2105 Promise', () => {
-            let postFn, serverData;
+            let postFn, getFn, serverData;
             beforeEach(() => {
                 serverData = {some: 'server data'};
                 postFn = sinon.spy();
+                getFn = sinon.spy();
             });
 
             describe('when creating an asset', () => {
@@ -157,7 +159,8 @@ describe('src/V1Meta', function() {
             describe('when querying for a definition', () => {
                 beforeEach(() => {
                     actual = (new Sut({ ...v1ServerInfowithUsernamePassword,
-                        postFn
+                        postFn,
+                        getFn
                     })).queryDefinition("Story")
                 });
                 it('it should return an ES2015 Promise', () => {
@@ -167,15 +170,19 @@ describe('src/V1Meta', function() {
         });
 
         describe('given post and get methods which does return an ES2015 promise', () => {
-            let postFn, serverData;
+            let postFn, getFn, serverData;
             beforeEach(() => {
                 serverData = {server: 'data'};
                 postFn = sinon.stub().returns(new Promise((resolve) => {
                     resolve(serverData);
                 }));
+                getFn = sinon.stub().returns(new Promise((resolve) => {
+                    resolve(serverData);
+                }));
             });
             afterEach(() => {
                 sinon.restore(postFn);
+                sinon.restore(getFn);
             });
 
             describe('given an asset type and asset attributes', () => {
@@ -417,18 +424,20 @@ describe('src/V1Meta', function() {
                 describe('when query for a definition', () => {
                     beforeEach(() => {
                         postFn = sinon.stub().returns(Promise.resolve());
+                        getFn = sinon.stub().returns(Promise.resolve());
                         getUrlsForV1Server = sinon.stub().withArgs({...v1ServerInfo}).returns({
                             meta: sinon.stub().returns(url)
                         });
                         Sut.__Rewire__('getUrlsForV1Server', getUrlsForV1Server);
                         actual = (new Sut({
                             ...v1ServerInfowithUsernamePassword,
-                            postFn
+                            postFn,
+                            getFn
                         })).queryDefinition(assetType);
                     });
 
-                    it('it should provide the postFn with the proper API URL for the assetType', () => {
-                        postFn.calledWith(`${url}/${assetType}`, null, expectedHeaders).should.be.true;
+                    it('it should provide the getFn with the proper API URL for the assetType', () => {
+                        getFn.calledWith(`${url}/${assetType}`, null, expectedHeaders).should.be.true;
                     });
                 });
             });

--- a/src/V1Server.js
+++ b/src/V1Server.js
@@ -2,7 +2,8 @@ export function getUrlsForV1Server({hostname, instance, protocol, port}) {
     const rootUrl = getUrlToV1Server({hostname, instance, protocol, port});
     return {
         rest: () => restUrl(rootUrl),
-        query: () => queryUrl(rootUrl)
+        query: () => queryUrl(rootUrl),
+        meta: () => metaUrl(rootUrl)
     };
 }
 
@@ -14,10 +15,8 @@ function getUrlToV1Server({hostname, instance, protocol, port}) {
     return `${url}/${instance}`;
 }
 
-function restUrl(rootUrl) {
-    return `${rootUrl}/rest-1.v1/Data`;
-}
+const restUrl = rootUrl => `${rootUrl}/rest-1.v1/Data`;
 
-function queryUrl(rootUrl) {
-    return `${rootUrl}/query.v1`;
-}
+const queryUrl = rootUrl => `${rootUrl}/query.v1`;
+
+const metaUrl = rootUrl => `${rootUrl}/meta.v1`;

--- a/src/V1Server.specs.js
+++ b/src/V1Server.specs.js
@@ -46,5 +46,15 @@ describe('src/V1Server', function() {
                 actual.should.equal('https://some URL:8081/some Instance/query.v1');
             });
         });
+
+        describe('when getting the meta.v1 Url', () => {
+            beforeEach(() => {
+                actual = Sut.getUrlsForV1Server(v1ServerInfo).meta();
+            });
+
+            it('it should return the Rest API Url', () => {
+                actual.should.equal('https://some URL:8081/some Instance/meta.v1');
+            });
+        });
     });
 });

--- a/src/V1Server.specs.js
+++ b/src/V1Server.specs.js
@@ -52,7 +52,7 @@ describe('src/V1Server', function() {
                 actual = Sut.getUrlsForV1Server(v1ServerInfo).meta();
             });
 
-            it('it should return the Rest API Url', () => {
+            it('it should return the Meta API Url', () => {
                 actual.should.equal('https://some URL:8081/some Instance/meta.v1');
             });
         });


### PR DESCRIPTION
💃  @andrew-codes @mhh Also this would not run the linter on my version on node. Maybe we should add what version(s) of node are supported in the package.json by adding `engines` and enforce the usage of those versions with `engineStrict`