### PR TITLE
Add urls for activity stream api

### DIFF
--- a/src/createMeta.js
+++ b/src/createMeta.js
@@ -53,8 +53,7 @@ export default (hostname, instance, protocol, port, token, postFn, getFn, isBasi
 
         getActivityStream(oidToken) {
             invariant(oidToken, `Error: there was no \`oidToken\` provided to execute operation`);
-            const oid = new Oid(oidToken);
-            const url = `${urls.activityStream}/${oid.assetType}/${oid.number}`;
+            const url = `${urls.activityStream}/${oidToken}`;
             return getFn(url, null, headers);
         }
     };

--- a/src/createMeta.js
+++ b/src/createMeta.js
@@ -49,6 +49,13 @@ export default (hostname, instance, protocol, port, token, postFn, getFn, isBasi
             const queryAssetType = assetType ? assetType : '';
             const url = `${urls.meta}/${queryAssetType}`;
             return getFn(url, null, headers);
+        },
+
+        getActivityStream(oidToken) {
+            invariant(oidToken, `Error: there was no \`oidToken\` provided to execute operation`);
+            const oid = new Oid(oidToken);
+            const url = `${urls.activityStream}/${oid.assetType}/${oid.number}`;
+            return getFn(url, null, headers);
         }
     };
 };

--- a/src/createMeta.specs.js
+++ b/src/createMeta.specs.js
@@ -532,7 +532,7 @@ describe('src/meta.queryDefinition', function() {
                 const getV1Urls = sinon.mock()
                     .withArgs('h', 'i', 'http', 80)
                     .returns({
-                        meta: 'meta URL'
+                        activityStream: 'activityStream URL'
                     });
                 RewireApi.__Rewire__('getV1Urls', getV1Urls);
                 this.getFn = sinon.stub();
@@ -543,8 +543,8 @@ describe('src/meta.queryDefinition', function() {
             afterEach(() => {
                 RewireApi.__ResetDependency__('getV1Urls');
             });
-            it('it should post the the operation to the REST URL endpoint', () => {
-                this.getFn.calledWith(`meta URL/Story:1234`, null, this.headers).should.be.true;
+            it('it should query the ActivityStream endpoint', () => {
+                this.getFn.calledWith(`activityStream URL/Story:1234`, null, this.headers).should.be.true;
             });
         });
     });

--- a/src/createMeta.specs.js
+++ b/src/createMeta.specs.js
@@ -33,6 +33,9 @@ describe('src/meta', function() {
             it('it should return an object with a query definition function', () => {
                 this.actual.queryDefinition.should.be.a('function');
             });
+            it('it should return an object with a activity stream function', () => {
+                this.actual.getActivityStream.should.be.a('function');
+            });
         });
     });
 });
@@ -515,6 +518,33 @@ describe('src/meta.queryDefinition', function() {
             });
             it('it should post the the operation to the REST URL endpoint', () => {
                 this.getFn.calledWith(`meta URL/Actual`, null, this.headers).should.be.true;
+            });
+        });
+    });
+    describe('given an oidToken', () => {
+        describe('when retreiving an activity stream for the asset', () => {
+            beforeEach(() => {
+                this.headers = {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer token'
+                };
+                const getV1Urls = sinon.mock()
+                    .withArgs('h', 'i', 'http', 80)
+                    .returns({
+                        meta: 'meta URL'
+                    });
+                RewireApi.__Rewire__('getV1Urls', getV1Urls);
+                this.getFn = sinon.stub();
+
+                this.meta = createMeta('h', 'i', 'http', 80, 'token', null, this.getFn, false);
+                this.actual = this.meta.getActivityStream('Story:1234');
+            });
+            afterEach(() => {
+                RewireApi.__ResetDependency__('getV1Urls');
+            });
+            it('it should post the the operation to the REST URL endpoint', () => {
+                this.getFn.calledWith(`meta URL/Story/1234`, null, this.headers).should.be.true;
             });
         });
     });

--- a/src/createMeta.specs.js
+++ b/src/createMeta.specs.js
@@ -544,7 +544,7 @@ describe('src/meta.queryDefinition', function() {
                 RewireApi.__ResetDependency__('getV1Urls');
             });
             it('it should post the the operation to the REST URL endpoint', () => {
-                this.getFn.calledWith(`meta URL/Story/1234`, null, this.headers).should.be.true;
+                this.getFn.calledWith(`meta URL/Story:1234`, null, this.headers).should.be.true;
             });
         });
     });

--- a/src/getV1Urls.js
+++ b/src/getV1Urls.js
@@ -3,7 +3,8 @@ export default (hostname, instance, protocol, port) => {
     return Object.freeze({
         rest: `${rootUrl}/rest-1.v1/Data`,
         query: `${rootUrl}/query.v1`,
-        meta: `${rootUrl}/meta.v1`
+        meta: `${rootUrl}/meta.v1`,
+        activityStream: `${rootUrl}/api/ActivityStream`
     });
 };
 

--- a/src/getV1Urls.specs.js
+++ b/src/getV1Urls.specs.js
@@ -24,7 +24,7 @@ describe('src/getV1Urls', function() {
                 this.actual.meta.should.equal('https://some URL:8081/some Instance/meta.v1');
             });
             it('it should return the Activity Stream API URL', () => {
-                this.actual.activityStream.should.equal('https://some URL:8081/some Instance/api/activityStream');
+                this.actual.activityStream.should.equal('https://some URL:8081/some Instance/api/ActivityStream');
             });
         });
     });

--- a/src/getV1Urls.specs.js
+++ b/src/getV1Urls.specs.js
@@ -23,6 +23,9 @@ describe('src/getV1Urls', function() {
             it('it should return the Meta API URL', () => {
                 this.actual.meta.should.equal('https://some URL:8081/some Instance/meta.v1');
             });
+            it('it should return the Activity Stream API URL', () => {
+                this.actual.activityStream.should.equal('https://some URL:8081/some Instance/api/activityStream');
+            });
         });
     });
 });


### PR DESCRIPTION
`<root-url>/api/ActivityStream/<assetType>/<id>` Returns the activity stream of an asset.